### PR TITLE
[fix] center video content by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ I attempt to follow the [Conventional Commits](https://www.conventionalcommits.o
 ### Fixed
 
 - fix(Quotes): typo, dwyl, backup quotable api. [#4faa4d1](https://github.com/BookCatKid/TablissNG/commit/4faa4d107e9dbd1a1c68e992bc3b2883b63cfc9e)
+- fix: make video content centered by default.
 
 ## [1.4.0] - 4/24/2025 | Feature Update
 

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -55,3 +55,8 @@ i:not(custom-icon) > svg
 
 textarea
     overflow-y: scroll !important
+
+.video
+    object-fit: cover
+    width: 100%
+    height: 100%


### PR DESCRIPTION
## Description
made it so video content is centered by default

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Translation update

## Changelog Entry
- fix: center video content by default

## Screenshots
![Screen Shot](https://github.com/user-attachments/assets/bfb7d1ee-4bf4-4813-ad10-7df27db948e3)

## Checklist

- [x] Tested in development environment
- [x] Tested in Firefox
- [x] Tested in Chrome/Edge
- [ ] Added or updated unit tests (if applicable)
- [x] All new and existing tests passed
- [x] I have added a changelog entry
