### PR TITLE
change resize mode of textareas to vertical to prevent resizing them …

### DIFF
--- a/src/plugins/widgets/css/CssSettings.tsx
+++ b/src/plugins/widgets/css/CssSettings.tsx
@@ -12,7 +12,7 @@ const CssSettings: FC<Props> = ({ data = defaultData, setData }) => (
         />
       <textarea
         rows={3}
-        style={{ fontFamily: "monospace" }}
+        style={{ resize: "vertical", fontFamily: "monospace" }}
         value={data.input}
         onChange={(event) => setData({ input: event.target.value })}
       />

--- a/src/plugins/widgets/customText/CustomTextSettings.tsx
+++ b/src/plugins/widgets/customText/CustomTextSettings.tsx
@@ -100,7 +100,7 @@ const CustomTextSettings: FC<Props> = ({ data = defaultData, setData }) => {
           description="Label for text input"
         />
         <textarea
-          style={{ resize: "none", overflow: "scroll" }}
+          style={{ resize: "vertical", overflow: "scroll" }}
           value={data.text}
           rows={10}
           onChange={(event) => setData({ ...data, text: event.target.value })}

--- a/src/plugins/widgets/html/HtmlSettings.tsx
+++ b/src/plugins/widgets/html/HtmlSettings.tsx
@@ -17,7 +17,7 @@ const HtmlSettings: FC<Props> = ({ data = defaultData, setData }) => {
         />
         <textarea
           rows={3}
-          style={{ fontFamily: "monospace" }}
+          style={{ resize: "vertical", fontFamily: "monospace" }}
           value={input}
           onChange={(event) => setInput(event.target.value)}
         />

--- a/src/plugins/widgets/js/JsSettings.tsx
+++ b/src/plugins/widgets/js/JsSettings.tsx
@@ -17,7 +17,7 @@ const JsSettings: FC<Props> = ({ data = defaultData, setData }) => {
         />
         <textarea
           rows={3}
-          style={{ fontFamily: "monospace" }}
+          style={{ resize: "vertical", fontFamily: "monospace" }}
           value={input}
           onChange={(event) => setInput(event.target.value)}
         />

--- a/src/plugins/widgets/links/Input.tsx
+++ b/src/plugins/widgets/links/Input.tsx
@@ -311,6 +311,7 @@ const Input: FC<Props> = (props) => {
           />
           <textarea
             value={props.SvgString}
+            style={{ resize: "vertical"}}
             onChange={(event) =>
               props.onChange({ SvgString: event.target.value })
             }

--- a/src/plugins/widgets/message/MessageSettings.tsx
+++ b/src/plugins/widgets/message/MessageSettings.tsx
@@ -23,6 +23,7 @@ const MessageSettings: FC<Props> = ({ data = defaultData, setData }) => {
         />
         <textarea
           rows={3}
+          style={{ resize: "vertical"}}
           placeholder={intl.formatMessage(messages.messagePlaceholder)}
           value={data.messages[0]}
           onChange={(event) => setData({ messages: [event.target.value] })}


### PR DESCRIPTION
…into unclickable areas

## Description

Textareas in several widgets settings screen can be resized horizontally beyond the limits of the containing divs.
To reproduce this just click and hold the resizing corner in a text areas lower right corner and pull it to the right beyond the border of the parent div. It will be hidden under the side of the settings sidebar.
This change limits resizing to the vertical direction stopping the user from being unable to resize the textareas after pulling it beyond the settings sidebar.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Translation update <!-- If your change is a Translation update, PLEASE run `npm run translation` before you start editing and after before commiting. Then check the box at the bottom of the checklist.-->

## Changelog Entry

fix: change resize mode of textareas to vertical to prevent resizing them into unclickable areas

## Screenshots

## Related Issues

## Checklist

- [x] Tested in development environment
- [x] Tested in Firefox
- [ ] Tested in Chrome/Edge
- [ ] Added or updated unit tests (if applicable)
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry
- [ ] I ran `npm run translations`
- [x] This PR is ready to be merged
