### PR TITLE
Set default display.scale to true

### DIFF
--- a/src/views/settings/Background.tsx
+++ b/src/views/settings/Background.tsx
@@ -195,7 +195,7 @@ const Background: React.FC = () => {
                 <label>
                   <input
                     type="checkbox"
-                    checked={data.display.scale}
+                    checked={data.display.scale ?? true}
                     onChange={(e) => {
                       setBackgroundDisplay({
                         scale: e.target.checked,

--- a/src/views/shared/Backdrop.tsx
+++ b/src/views/shared/Backdrop.tsx
@@ -37,7 +37,7 @@ const Backdrop: React.FC<Props> = ({
     }
   }
 
-  if (scale) {
+  if (scale || scale == null) {
     style["backgroundSize"] = "cover";
   } else if (!scale) {
     style["backgroundSize"] = "contain";


### PR DESCRIPTION
## Description

When importing from Tabliss, Unsplash images were not scaling correctly.
This fix defaults `data.display.scale` to `true`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Translation update <!-- If your change is a Translation update, PLEASE run `npm run translation` before you start editing and after before commiting. Then check the box at the bottom of the checklist.-->

<!-- Add a changelog entry in the format used in CHANGELOG.md. This helps with creating releases. Then, paste your entry here. -->

## Related Issues
#61

## Checklist

- [x] Tested in development environment
- [x] Tested in Firefox
- [x] Tested in Chrome/Edge
- [ ] Added or updated unit tests (if applicable)
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry
- [ ] I ran `npm run translations`
- [x] This PR is ready to be merged
